### PR TITLE
Return if there is no ref

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ export function useSticky() {
     // Observe when ref enters or leaves sticky state
     // rAF https://stackoverflow.com/questions/41740082/scroll-events-requestanimationframe-vs-requestidlecallback-vs-passive-event-lis
     function observe() {
+      if(!stickyRef.current) return;
       const refPageOffset = stickyRef.current.getBoundingClientRect().top;
       const stickyOffset = parseInt(getComputedStyle(stickyRef.current).top);
       const stickyActive = refPageOffset <= stickyOffset;


### PR DESCRIPTION
Sometimes while you are waiting for data, you need to return early from a component and then this hook gets mad because there isn't a ref for it. 